### PR TITLE
Add --s3_full_control_userid

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -49,6 +49,14 @@ public final class RemoteOptions extends OptionsBase {
   )
   public String s3CacheBucket;
 
+  @Option(
+      name = "s3_full_control_userid",
+      defaultValue = "null",
+      category = "remote",
+      help = "An AWS canonical user id for a user who should have full control over uploaded objects"
+  )
+  public String s3FullControlUserId;
+
   @Option(name = "remote_fallback_strategy",
     allowMultiple = true,
     converter = AssignmentConverter.class,


### PR DESCRIPTION
Add the ability to specify an S3 user who will have full control over any objects that are uploaded to the S3-based remote cache.